### PR TITLE
docs(repository): Configure repository metadata

### DIFF
--- a/.repository/index.json
+++ b/.repository/index.json
@@ -1,0 +1,22 @@
+{
+  "slug": "entity-net",
+  "namespace": "jrbeverly",
+  "status": "archived",
+  "icon": "icon.svg",
+  "license": {
+    "type": "MIT",
+    "content": "Jonathan Beverly <jrbeverly>"
+  },
+  "topics": [
+    "prototype",
+    "experiment",
+    "demonstration",
+    "orm",
+    "strongly-typed",
+    "code-generation"
+  ],
+  "languages": [
+    "C#",
+    "Dockerfile"
+  ]
+}


### PR DESCRIPTION
Configure the repository metadata in code, from the github data.

Standardize the github data on topics, taglines and other properties into a repository definition file. For now this can be json instead of YAML, as that is easier to get started with. Later work can be done to convert this to a YAML format.